### PR TITLE
[Feat] 입력 유효성 검사 추가 

### DIFF
--- a/src/Pages/Auth/RegisterPage/Register.tsx
+++ b/src/Pages/Auth/RegisterPage/Register.tsx
@@ -94,11 +94,12 @@ export const Label = styled.label`
 `;
 
 export const Input = styled.input.attrs({ type: "text" })`
-  width: 100%;
+  width: 80%;
   height: 3vh;
   border: none;
   background: transparent;
   font-size: 20px;
+  color: #fff;
   margin-bottom: 15px;
   margin-left: 10px;
   &::placeholder {
@@ -132,16 +133,10 @@ export const RegisterPage = () => {
           <span>Create new Account</span>
         </Title>
         <Form>
-          <UserContainer>
-            <UserLabel>
-              <Label>User ID</Label>
-              <Input placeholder="User ID" />
-            </UserLabel>
-            <UserLabel>
-              <Label>Nickname</Label>
-              <Input placeholder="Nickname" />
-            </UserLabel>
-          </UserContainer>
+          <LabelContainer>
+            <Label>User ID</Label>
+            <Input placeholder="User ID" />
+          </LabelContainer>
           <LabelContainer>
             <Label>Password</Label>
             <Input placeholder="User Password" />

--- a/src/Pages/Auth/RegisterPage/Register.tsx
+++ b/src/Pages/Auth/RegisterPage/Register.tsx
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+import { useForm } from "react-hook-form";
 import img from "../../../img/grape_background.png";
 import logo from "../../../img/logo.png";
 
@@ -72,17 +73,6 @@ export const LabelContainer = styled.div`
   margin-bottom: 20px;
 `;
 
-const UserContainer = styled.div`
-  display: flex;
-  flex-direction: row;
-  gap: 20px;
-`;
-
-const UserLabel = styled(LabelContainer)`
-  width: 190px;
-  height: 70px;
-`;
-
 export const Label = styled.label`
   color: rgba(252, 253, 242, 0.8);
   display: flex;
@@ -107,6 +97,8 @@ export const Input = styled.input.attrs({ type: "text" })`
   }
 `;
 
+export const PasswordInput = styled(Input).attrs({ type: "password" })``;
+
 export const Submit = styled.input`
   display: flex;
   justify-content: center;
@@ -121,7 +113,38 @@ export const Submit = styled.input`
   margin-top: 50px;
 `;
 
+export const ErrorMessage = styled.span`
+  color: #fff;
+  font-size: 12px;
+  margin-top: 5px;
+`;
+
+interface IForm {
+  username: string;
+  password: string;
+  checkpassword: string;
+  email: string;
+}
+
 export const RegisterPage = () => {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    setError,
+  } = useForm<IForm>();
+
+  const onValid = (data: IForm) => {
+    if (data.password !== data.checkpassword) {
+      setError(
+        "checkpassword",
+        { message: "비밀번호가 일치하지 않습니다." },
+        { shouldFocus: true }
+      );
+    }
+    console.log(data);
+  };
+
   return (
     <Wrapper image={img}>
       <LogoContainer>
@@ -132,22 +155,66 @@ export const RegisterPage = () => {
         <Title>
           <span>Create new Account</span>
         </Title>
-        <Form>
+        <Form onSubmit={handleSubmit(onValid)}>
           <LabelContainer>
             <Label>User ID</Label>
-            <Input placeholder="User ID" />
+            <Input
+              {...register("username", {
+                required: "User ID를 작성해주세요.",
+                minLength: {
+                  value: 3,
+                  message: "3 ~ 20 사이의 글자로 작성해주세요.",
+                },
+                maxLength: {
+                  value: 20,
+                  message: "3 ~ 20 사이의 글자로 작성해주세요.",
+                },
+              })}
+              placeholder="User ID"
+            />
+            <ErrorMessage>{errors?.username?.message}</ErrorMessage>
           </LabelContainer>
           <LabelContainer>
             <Label>Password</Label>
-            <Input placeholder="User Password" />
+            <PasswordInput
+              {...register("password", {
+                required: "Password를 작성해주세요.",
+                minLength: {
+                  value: 6,
+                  message: "6 ~ 40 사이의 글자로 작성해주세요.",
+                },
+                maxLength: {
+                  value: 40,
+                  message: "6 ~ 40 사이의 글자로 작성해주세요.",
+                },
+              })}
+              type="password"
+              placeholder="User Password"
+            />
+            <ErrorMessage>{errors?.password?.message}</ErrorMessage>
           </LabelContainer>
           <LabelContainer>
             <Label>Check Password</Label>
-            <Input placeholder="Check Password" />
+            <PasswordInput
+              {...register("checkpassword")}
+              placeholder="Check Password"
+              type="password"
+            />
+            <ErrorMessage>{errors?.checkpassword?.message}</ErrorMessage>
           </LabelContainer>
           <LabelContainer>
             <Label>Email</Label>
-            <Input placeholder="Email" />
+            <Input
+              {...register("email", {
+                required: "이메일을 입력해주세요.",
+                pattern: {
+                  value: /^[a-zA-Z0-9+-\_.]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$/,
+                  message: "이메일 형식으로 입력해주세요.",
+                },
+              })}
+              placeholder="Email"
+            />
+            <ErrorMessage>{errors?.email?.message}</ErrorMessage>
           </LabelContainer>
           <Submit type="submit" value="Create New Account" />
         </Form>


### PR DESCRIPTION
## 관련 이슈 
#11 

## 구현 사항
react hook form을 이용해 유효성 검사 
### 입력 유효성 검사 
username 
- 필수로 입력 
- 3 ~ 20자 사이 입력 
![image](https://github.com/GDSC-Team-4/Mango_FrontEnd/assets/76934619/b90d31fe-5430-4436-8294-93ef3a5bdbe0)
![image](https://github.com/GDSC-Team-4/Mango_FrontEnd/assets/76934619/3456e871-9704-444a-8db7-7cd00a61850c)

password
- 필수로 입력 
- 6 ~ 40자 사이 입력 
- 패스워드 일치 여부 
![image](https://github.com/GDSC-Team-4/Mango_FrontEnd/assets/76934619/3caaccec-ddd3-4605-9513-edf849e2606e)
![image](https://github.com/GDSC-Team-4/Mango_FrontEnd/assets/76934619/3eb40b94-7594-40e2-906c-8974cc72b2ff)
![image](https://github.com/GDSC-Team-4/Mango_FrontEnd/assets/76934619/b0726c65-644c-4589-85f6-5eb7d8d671d2)

email
- 필수로 입력 
- 이메일 형식 검사
![image](https://github.com/GDSC-Team-4/Mango_FrontEnd/assets/76934619/7ca661ba-7787-4493-8959-d93fee8ddbf9)
![image](https://github.com/GDSC-Team-4/Mango_FrontEnd/assets/76934619/b4576506-cca9-4ab1-8eff-69659797462f)
![image](https://github.com/GDSC-Team-4/Mango_FrontEnd/assets/76934619/0c7fe77f-f4c6-446a-ab3d-e0bccc3c61d1)
![image](https://github.com/GDSC-Team-4/Mango_FrontEnd/assets/76934619/66c9cc80-5f9b-4f64-bedf-126a8332b4c8)
