### PR TITLE
[Feat] 회원가입 기능 

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,5 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "proxy": "http://localhost:8080"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -49,5 +49,6 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  }
+  },
+  "proxy": "http://localhost:8080"
 }

--- a/src/Interface/Register.ts
+++ b/src/Interface/Register.ts
@@ -1,0 +1,14 @@
+export interface IForm {
+  username: string;
+  password: string;
+  checkpassword: string;
+  email: string;
+}
+
+// post를 보낼 때 role도 포함되어 있어서 새로운 interface 사용
+export interface ISubmit {
+  username: string;
+  email: string;
+  password: string;
+  role: string[];
+}

--- a/src/Pages/Auth/LoginPage/Login.tsx
+++ b/src/Pages/Auth/LoginPage/Login.tsx
@@ -9,7 +9,7 @@ import {
   Label,
   Input,
   Submit,
-} from "../RegisterPage/Register";
+} from "../RegisterPage/StyledRegister";
 import img from "../../../img/grape_background.png";
 import logo from "../../../img/logo.png";
 import styled from "styled-components";

--- a/src/Pages/Auth/RegisterPage/ConstantRegister.ts
+++ b/src/Pages/Auth/RegisterPage/ConstantRegister.ts
@@ -1,0 +1,24 @@
+const USERNAME = {
+  MIN_LENGTH: 3,
+  MAX_LENGTH: 20,
+  REQUIRED_MESSAGE: "User ID를 작성해주세요.",
+  LENGTH_MESSAGE: "3 ~ 20 사이의 글자로 작성해주세요.",
+};
+
+const PASSWORD = {
+  MIN_LENGTH: 6,
+  MAX_LENGTH: 40,
+  REQUIRED_MESSAGE: "Password를 작성해주세요.",
+  LENGTH_MESSAGE: "6 ~ 40 사이의 글자로 작성해주세요.",
+  CHECK_MESSAGE: "비밀번호가 일치하지 않습니다.",
+};
+
+const EMAIL = {
+  REQUIRED_MESSAGE: "이메일을 입력해주세요.",
+  PATTERN: /^[a-zA-Z0-9+-\_.]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$/,
+  CHECK_MESSAGE: "이메일 형식으로 입력해주세요.",
+};
+
+const SUCCESS = "회원가입이 완료되었습니다.";
+
+export default { USERNAME, PASSWORD, EMAIL, SUCCESS };

--- a/src/Pages/Auth/RegisterPage/Register.tsx
+++ b/src/Pages/Auth/RegisterPage/Register.tsx
@@ -1,4 +1,3 @@
-import styled from "styled-components";
 import { useForm } from "react-hook-form";
 import img from "../../../img/grape_background.png";
 import logo from "../../../img/logo.png";
@@ -6,122 +5,20 @@ import { useRef } from "react";
 import axios from "axios";
 import { useNavigate } from "react-router-dom";
 import { IForm, ISubmit } from "../../../Interface/Register";
-
-export const Wrapper = styled.div<{ image: string }>`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 10%;
-  flex-direction: row;
-  background-image: linear-gradient(
-      rgba(37, 37, 45, 0.85),
-      rgba(37, 37, 45, 0.85)
-    ),
-    url(${(props) => props.image});
-  background-size: cover;
-  background-repeat: no-repeat;
-  gap: 10vw;
-`;
-
-export const LogoContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  span {
-    color: rgba(252, 253, 242, 0.7);
-    font-size: 50px;
-    font-weight: 600;
-    letter-spacing: 5px;
-    margin-top: -100px;
-  }
-`;
-
-export const Logo = styled.img``;
-
-export const Container = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  background-color: rgba(245, 235, 255, 0.4);
-  width: 30vw;
-  max-width: 600px;
-  max-height: 650px;
-  border-radius: 20px;
-  background: rgba(217, 217, 217, 0.1);
-  padding: 6% 2%;
-  border: none;
-`;
-
-export const Title = styled.div`
-  display: flex;
-  margin-bottom: 50px;
-  justify-content: center;
-  color: #fcfdf2;
-  font-size: 40px;
-  font-weight: 600;
-  width: 100%;
-  span {
-  }
-`;
-
-export const Form = styled.form``;
-
-export const LabelContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  border-radius: 10px;
-  background: rgba(217, 217, 217, 0.4);
-  box-shadow: 0px 4px 10px 0px rgba(255, 255, 255, 0.1);
-  width: 400px;
-  height: 70px;
-  margin-bottom: 20px;
-`;
-
-export const Label = styled.label`
-  color: rgba(252, 253, 242, 0.8);
-  display: flex;
-  height: 100%;
-  font-size: 12px;
-  font-weight: 600;
-  margin-top: 10px;
-  margin-left: 10px;
-`;
-
-export const Input = styled.input.attrs({ type: "text" })`
-  width: 80%;
-  height: 3vh;
-  border: none;
-  background: transparent;
-  font-size: 20px;
-  color: #fff;
-  margin-bottom: 15px;
-  margin-left: 10px;
-  &::placeholder {
-    color: #fff;
-  }
-`;
-
-export const PasswordInput = styled(Input).attrs({ type: "password" })``;
-
-export const Submit = styled.input`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  width: 100%;
-  height: 50px;
-  border: none;
-  border-radius: 100px;
-  background: rgba(37, 37, 45, 0.7);
-  color: #fff;
-  font-size: 20px;
-  margin-top: 50px;
-`;
-
-export const ErrorMessage = styled.span`
-  color: #fff;
-  font-size: 12px;
-  margin-top: 5px;
-`;
+import {
+  Container,
+  ErrorMessage,
+  Form,
+  Input,
+  Label,
+  LabelContainer,
+  Logo,
+  LogoContainer,
+  PasswordInput,
+  Submit,
+  Title,
+  Wrapper,
+} from "./StyledRegister";
 
 export const RegisterPage = () => {
   const {

--- a/src/Pages/Auth/RegisterPage/Register.tsx
+++ b/src/Pages/Auth/RegisterPage/Register.tsx
@@ -5,6 +5,7 @@ import logo from "../../../img/logo.png";
 import { useRef } from "react";
 import axios from "axios";
 import { useNavigate } from "react-router-dom";
+import { IForm, ISubmit } from "../../../Interface/Register";
 
 export const Wrapper = styled.div<{ image: string }>`
   display: flex;
@@ -121,20 +122,6 @@ export const ErrorMessage = styled.span`
   font-size: 12px;
   margin-top: 5px;
 `;
-
-interface IForm {
-  username: string;
-  password: string;
-  checkpassword: string;
-  email: string;
-}
-
-interface ISubmit {
-  username: string;
-  email: string;
-  password: string;
-  role: string[];
-}
 
 export const RegisterPage = () => {
   const {

--- a/src/Pages/Auth/RegisterPage/Register.tsx
+++ b/src/Pages/Auth/RegisterPage/Register.tsx
@@ -2,6 +2,9 @@ import styled from "styled-components";
 import { useForm } from "react-hook-form";
 import img from "../../../img/grape_background.png";
 import logo from "../../../img/logo.png";
+import { useRef } from "react";
+import axios from "axios";
+import { useNavigate } from "react-router-dom";
 
 export const Wrapper = styled.div<{ image: string }>`
   display: flex;
@@ -126,6 +129,13 @@ interface IForm {
   email: string;
 }
 
+interface ISubmit {
+  username: string;
+  email: string;
+  password: string;
+  role: string[];
+}
+
 export const RegisterPage = () => {
   const {
     register,
@@ -133,6 +143,8 @@ export const RegisterPage = () => {
     formState: { errors },
     setError,
   } = useForm<IForm>();
+  const formData = useRef<ISubmit>();
+  const navigate = useNavigate();
 
   const onValid = (data: IForm) => {
     if (data.password !== data.checkpassword) {
@@ -141,8 +153,24 @@ export const RegisterPage = () => {
         { message: "비밀번호가 일치하지 않습니다." },
         { shouldFocus: true }
       );
+    } else {
+      formData.current = {
+        username: data.username,
+        email: data.email,
+        password: data.password,
+        role: ["user"],
+      };
+
+      axios
+        .post("http://localhost:8080/api/auth/signup", formData.current)
+        .then((response) => {
+          alert("회원가입이 완료되었습니다.");
+          navigate("/");
+        })
+        .catch(({ response }) => {
+          alert(response.data.message);
+        });
     }
-    console.log(data);
   };
 
   return (

--- a/src/Pages/Auth/RegisterPage/Register.tsx
+++ b/src/Pages/Auth/RegisterPage/Register.tsx
@@ -5,6 +5,7 @@ import { useRef } from "react";
 import axios from "axios";
 import { useNavigate } from "react-router-dom";
 import { IForm, ISubmit } from "../../../Interface/Register";
+import constant from "./ConstantRegister";
 import {
   Container,
   ErrorMessage,
@@ -34,7 +35,7 @@ export const RegisterPage = () => {
     if (data.password !== data.checkpassword) {
       setError(
         "checkpassword",
-        { message: "비밀번호가 일치하지 않습니다." },
+        { message: constant.PASSWORD.CHECK_MESSAGE },
         { shouldFocus: true }
       );
     } else {
@@ -48,7 +49,7 @@ export const RegisterPage = () => {
       axios
         .post("http://localhost:8080/api/auth/signup", formData.current)
         .then((response) => {
-          alert("회원가입이 완료되었습니다.");
+          alert(constant.SUCCESS);
           navigate("/");
         })
         .catch(({ response }) => {
@@ -65,21 +66,21 @@ export const RegisterPage = () => {
       </LogoContainer>
       <Container>
         <Title>
-          <span>Create new Account</span>
+          <span>Create New Account</span>
         </Title>
         <Form onSubmit={handleSubmit(onValid)}>
           <LabelContainer>
             <Label>User ID</Label>
             <Input
               {...register("username", {
-                required: "User ID를 작성해주세요.",
+                required: constant.USERNAME.REQUIRED_MESSAGE,
                 minLength: {
-                  value: 3,
-                  message: "3 ~ 20 사이의 글자로 작성해주세요.",
+                  value: constant.USERNAME.MIN_LENGTH,
+                  message: constant.USERNAME.LENGTH_MESSAGE,
                 },
                 maxLength: {
-                  value: 20,
-                  message: "3 ~ 20 사이의 글자로 작성해주세요.",
+                  value: constant.USERNAME.MAX_LENGTH,
+                  message: constant.USERNAME.LENGTH_MESSAGE,
                 },
               })}
               placeholder="User ID"
@@ -90,14 +91,14 @@ export const RegisterPage = () => {
             <Label>Password</Label>
             <PasswordInput
               {...register("password", {
-                required: "Password를 작성해주세요.",
+                required: constant.PASSWORD.REQUIRED_MESSAGE,
                 minLength: {
-                  value: 6,
-                  message: "6 ~ 40 사이의 글자로 작성해주세요.",
+                  value: constant.PASSWORD.MIN_LENGTH,
+                  message: constant.PASSWORD.LENGTH_MESSAGE,
                 },
                 maxLength: {
-                  value: 40,
-                  message: "6 ~ 40 사이의 글자로 작성해주세요.",
+                  value: constant.PASSWORD.MAX_LENGTH,
+                  message: constant.PASSWORD.LENGTH_MESSAGE,
                 },
               })}
               type="password"
@@ -118,10 +119,10 @@ export const RegisterPage = () => {
             <Label>Email</Label>
             <Input
               {...register("email", {
-                required: "이메일을 입력해주세요.",
+                required: constant.EMAIL.REQUIRED_MESSAGE,
                 pattern: {
-                  value: /^[a-zA-Z0-9+-\_.]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$/,
-                  message: "이메일 형식으로 입력해주세요.",
+                  value: constant.EMAIL.PATTERN,
+                  message: constant.EMAIL.CHECK_MESSAGE,
                 },
               })}
               placeholder="Email"

--- a/src/Pages/Auth/RegisterPage/StyledRegister.tsx
+++ b/src/Pages/Auth/RegisterPage/StyledRegister.tsx
@@ -1,0 +1,117 @@
+import styled from "styled-components";
+
+export const Wrapper = styled.div<{ image: string }>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10%;
+  flex-direction: row;
+  background-image: linear-gradient(
+      rgba(37, 37, 45, 0.85),
+      rgba(37, 37, 45, 0.85)
+    ),
+    url(${(props) => props.image});
+  background-size: cover;
+  background-repeat: no-repeat;
+  gap: 10vw;
+`;
+
+export const LogoContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  span {
+    color: rgba(252, 253, 242, 0.7);
+    font-size: 50px;
+    font-weight: 600;
+    letter-spacing: 5px;
+    margin-top: -100px;
+  }
+`;
+
+export const Logo = styled.img``;
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background-color: rgba(245, 235, 255, 0.4);
+  width: 30vw;
+  max-width: 600px;
+  max-height: 650px;
+  border-radius: 20px;
+  background: rgba(217, 217, 217, 0.1);
+  padding: 6% 2%;
+  border: none;
+`;
+
+export const Title = styled.div`
+  display: flex;
+  margin-bottom: 50px;
+  justify-content: center;
+  color: #fcfdf2;
+  font-size: 40px;
+  font-weight: 600;
+  width: 100%;
+  span {
+  }
+`;
+
+export const Form = styled.form``;
+
+export const LabelContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  border-radius: 10px;
+  background: rgba(217, 217, 217, 0.4);
+  box-shadow: 0px 4px 10px 0px rgba(255, 255, 255, 0.1);
+  width: 400px;
+  height: 70px;
+  margin-bottom: 20px;
+`;
+
+export const Label = styled.label`
+  color: rgba(252, 253, 242, 0.8);
+  display: flex;
+  height: 100%;
+  font-size: 12px;
+  font-weight: 600;
+  margin-top: 10px;
+  margin-left: 10px;
+`;
+
+export const Input = styled.input.attrs({ type: "text" })`
+  width: 80%;
+  height: 3vh;
+  border: none;
+  background: transparent;
+  font-size: 20px;
+  color: #fff;
+  margin-bottom: 15px;
+  margin-left: 10px;
+  &::placeholder {
+    color: #fff;
+  }
+`;
+
+export const PasswordInput = styled(Input).attrs({ type: "password" })``;
+
+export const Submit = styled.input`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 50px;
+  border: none;
+  border-radius: 100px;
+  background: rgba(37, 37, 45, 0.7);
+  color: #fff;
+  font-size: 20px;
+  margin-top: 50px;
+`;
+
+export const ErrorMessage = styled.span`
+  color: #fff;
+  font-size: 12px;
+  margin-top: 5px;
+`;


### PR DESCRIPTION
## 관련 이슈
#11 

## 구현 사항
### 회원가입
회원가입에 성공하면 성공했다는 메시지와 함께 홈 화면으로 돌아갑니다. 
입력 폼에는 role이 없는데 요청 보낼 때 role이 필요해서 따로 interface를 따로 하나 더 만들었습니다. 

- 회원가입 성공
![image](https://github.com/GDSC-Team-4/Mango_FrontEnd/assets/76934619/99f3d3a1-cb7d-4fe1-b99e-b27de7219d6f)
alert 창 확인 누르면 홈 화면으로 이동 

- username이 존재하는 경우
![image](https://github.com/GDSC-Team-4/Mango_FrontEnd/assets/76934619/0024112e-3c71-4899-ad54-7e51e7871353)


- 이메일이 존재하는 경우 
![image](https://github.com/GDSC-Team-4/Mango_FrontEnd/assets/76934619/398a4ebf-cb8a-4f1d-af0c-827a83aad0b5)
